### PR TITLE
Improve cache handling

### DIFF
--- a/src/CGcoefficient.jl
+++ b/src/CGcoefficient.jl
@@ -24,15 +24,16 @@ include("util.jl")
 include("WignerSymbols.jl")
 include("floatWignerSymbols.jl")
 
-function __init__()
-    global _fbinomial_nmax = 67
-    global _fbinomial_data = Vector{Float64}(undef, binomial_data_size(get_fbinomial_nmax()))
+
+let
+    # Precompute at precompilation time
+    _fbinomial_nmax[] = 67
+    resize!(_fbinomial_data, binomial_data_size(get_fbinomial_nmax()))
     for n = 0:get_fbinomial_nmax()
         for k = 0:div(n, 2)
             get_fbinomial_data()[binomial_index(n, k)] = binomial(UInt64(n), UInt64(k))
         end
     end
-    nothing
 end
 
 end # module CGcoefficient

--- a/src/floatWignerSymbols.jl
+++ b/src/floatWignerSymbols.jl
@@ -1,7 +1,7 @@
-_fbinomial_data = Float64[]
-_fbinomial_nmax = Int(0)
-@inline get_fbinomial_data()::Vector{Float64} = _fbinomial_data::Vector{Float64}
-@inline get_fbinomial_nmax()::Int = _fbinomial_nmax::Int
+const _fbinomial_data = Float64[]
+const _fbinomial_nmax = Ref(0)
+@inline get_fbinomial_data() = _fbinomial_data
+@inline get_fbinomial_nmax() = _fbinomial_nmax[]
 
 """
     fbinomial(n::Integer, k::Integer)
@@ -34,9 +34,9 @@ function _extent_fbinomial_data(n::Int)
             for k = 0:div(m, 2)
                 get_fbinomial_data()[binomial_index(m, k)] = binomial(BigInt(m), BigInt(k))
             end
-            global _fbinomial_nmax = get_fbinomial_nmax() + 1
+            _fbinomial_nmax[] = get_fbinomial_nmax() + 1
         end
-        global _fbinomial_nmax = n
+        _fbinomial_nmax[] = n
     end
     nothing
 end


### PR DESCRIPTION
This includes a partially revert of b84fc2d533e8ad54da23c5498591e2c9becbc091.

1. The cache array never needed to be assigned to so it can definitely be a const.
2. The max size's handling is reverted to the version before b84fc2d533e8ad54da23c5498591e2c9becbc091 using a `Ref{Int}`. Julia 1.8+ could just use typed global.

    The original change to not use a `Ref` doesn't come with an explaination
    so I'm not sure why it's changed this way.

3. Move the precomputation into the precompilation step.

    The data is computed eagerly on loading anyway so it doesn't really save
    anything to not do it at precompilation time.

    This could in principle result in a larger compiled cache file size
    though if there's enough space to load it into memory there should be
    enough size to store it on the disk as well. Also, the compiled cache
    file size is actually smaller probably because the `__init__` function
    is gone.